### PR TITLE
feat: Update 26.1.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,10 +15,10 @@ val commitHash = Runtime
     }
 
 plugins {
-    kotlin("jvm") version "2.3.20-RC3"
-    kotlin("kapt") version "2.3.20-RC3"
-    id("com.gradleup.shadow") version "9.3.2"
-    id("io.papermc.paperweight.userdev") version "2.0.0-beta.19"
+    kotlin("jvm") version "2.4.0-Beta1"
+    kotlin("kapt") version "2.4.0-Beta1"
+    id("com.gradleup.shadow") version "9.4.1"
+    id("io.papermc.paperweight.userdev") version "2.0.0-beta.21"
     id("xyz.jpenilla.run-paper") version "3.0.2"
 }
 
@@ -26,7 +26,7 @@ group = "moe.oof"
 version = "$patch-Build-$commitHash"
 
 kotlin {
-    jvmToolchain(21)
+    jvmToolchain(25)
     compilerOptions {
         javaParameters = true
     }
@@ -44,30 +44,30 @@ repositories {
 
 dependencies {
     implementation(kotlin("stdlib"))
-    paperweight.paperDevBundle("1.21.11-R0.1-SNAPSHOT")
+    paperweight.paperDevBundle("26.1.2.build.+")
 
-    implementation("org.incendo:cloud-paper:2.0.0-beta.13")
+    implementation("org.incendo:cloud-paper:2.0.0-beta.15")
     implementation("org.incendo:cloud-annotations:2.0.0")
     implementation("org.incendo:cloud-kotlin-extensions:2.0.0")
     implementation("org.incendo:cloud-kotlin-coroutines-annotations:2.0.0")
     kapt("org.incendo:cloud-kotlin-coroutines-annotations:2.0.0")
     implementation("org.incendo:cloud-kotlin-extensions:2.0.0")
     implementation("org.incendo:cloud-processors-confirmation:1.0.0-rc.1")
-    implementation("io.ktor:ktor-client-core:2.3.13")
-    implementation("io.ktor:ktor-client-cio:2.3.5")
-    implementation("io.ktor:ktor-client-logging:2.0.3")
+    implementation("io.ktor:ktor-client-core:3.4.2")
+    implementation("io.ktor:ktor-client-cio:3.4.2")
+    implementation("io.ktor:ktor-client-logging:3.4.2")
     implementation("org.spongepowered:configurate-yaml:4.2.0")
     implementation("org.spongepowered:configurate-extra-kotlin:4.2.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2")
 
     implementation("fr.mrmicky:fastboard:2.1.5")
 
-    implementation("com.noxcrew.interfaces:interfaces:2.0.1-SNAPSHOT")
+    implementation("com.noxcrew.interfaces:interfaces:2.1.0-SNAPSHOT")
 }
 
 tasks {
     compileJava {
-        options.release = 21
+        options.release = 25
     }
     javadoc {
         options.encoding = Charsets.UTF_8.name() // We want UTF-8 for everything

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,4 @@
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.9.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 rootProject.name = "system"

--- a/src/main/kotlin/command/Hat.kt
+++ b/src/main/kotlin/command/Hat.kt
@@ -21,7 +21,7 @@ class Hat {
                 player.sendMessage(Formatting.allTags.deserialize("<red>You are not holding an item. Idiot...</red>"))
             } else {
                 val helmet = player.inventory.helmet
-                player.inventory.helmet = itemInHand
+                player.inventory.setHelmet(itemInHand)
                 player.inventory.setItemInMainHand(helmet ?: ItemStack(Material.AIR))
             }
         }

--- a/src/main/kotlin/command/Live.kt
+++ b/src/main/kotlin/command/Live.kt
@@ -1,6 +1,7 @@
 package command
 
 import chat.Formatting
+import chat.Formatting.allTags
 import io.papermc.paper.command.brigadier.CommandSourceStack
 import net.kyori.adventure.text.format.TextColor
 import org.bukkit.Bukkit
@@ -23,10 +24,10 @@ class Live {
         val player = css.sender as? Player ?: return
         if (LiveUtil.isLive(player)) {
             LiveUtil.stopLive(player)
-            Bukkit.getServer().sendMessage(Formatting.allTags.deserialize("<cloudiecolor>${player.name}</cloudiecolor> stopped streaming"))
+            Bukkit.getServer().sendMessage(allTags.deserialize("<cloudiecolor>${player.name}</cloudiecolor> stopped streaming"))
         } else {
             LiveUtil.startLive(player)
-            Bukkit.getServer().sendMessage(Formatting.allTags.deserialize("<cloudiecolor>${player.name}</cloudiecolor> went live"))
+            Bukkit.getServer().sendMessage(allTags.deserialize("<cloudiecolor>${player.name}</cloudiecolor> went live"))
         }
     }
 }
@@ -45,7 +46,7 @@ object LiveUtil {
         pendingTimeouts.remove(playerId)?.cancel()
         livePlayerIds.add(playerId)
         startOrReplaceLiveTask(player)
-        player.sendMessage("Live mode enabled.")
+        player.sendMessage(allTags.deserialize("Live mode enabled."))
     }
 
     fun stopLive(player: Player) {
@@ -54,7 +55,7 @@ object LiveUtil {
         pendingTimeouts.remove(playerId)?.cancel()
         liveTasks.remove(playerId)?.cancel()
         resetPlayerNames(player)
-        player.sendMessage("Live mode disabled.")
+        player.sendMessage(allTags.deserialize("Live mode disabled."))
     }
 
     fun onPlayerQuit(player: Player) {
@@ -79,7 +80,7 @@ object LiveUtil {
         if (!isLive(playerId)) return
 
         startOrReplaceLiveTask(player)
-        player.sendMessage("Live mode enabled.")
+        player.sendMessage(allTags.deserialize("Live mode enabled."))
     }
 
     fun shutdown() {

--- a/src/main/kotlin/command/Message.kt
+++ b/src/main/kotlin/command/Message.kt
@@ -34,7 +34,6 @@ class Message {
         if(css.sender is Player) {
             val sender = css.sender as Player
             if (sender == recipient) {
-                System.currentTimeMillis() / 1000
                 sender.sendMessage(Formatting.restrictedTags.deserialize("<i><cloudiecolor>You<white> -> <yellow>Yourself</yellow>: ${text.joinToString(" ")}</i>"))
             } else {
                 sendMessage(sender, recipient, text)

--- a/src/main/kotlin/command/Tpa.kt
+++ b/src/main/kotlin/command/Tpa.kt
@@ -198,9 +198,8 @@ class Tpa {
     private fun deleteTpaAfterDelay(player: Player, target: Player, requestTimeout: Int, tpaRequest: TpaRequest) {
         Bukkit.getScheduler().runTaskLater(plugin, Runnable {
             if (tpaRequests.remove(tpaRequest)) {
-                player.sendMessage(allTags.deserialize("<yellow>TPA Request to ${target.name} has timed out."))
-
-                target.sendMessage(allTags.deserialize("<yellow>TPA Request from <green>${player.name}</green> has timed out."))
+                Bukkit.getPlayer(player.uniqueId)?.sendMessage(allTags.deserialize("<yellow>TPA request to <green>${target.name}</green> has timed out."))
+                Bukkit.getPlayer(target.uniqueId)?.sendMessage(allTags.deserialize("<yellow>TPA Request from <green>${player.name}</green> has timed out."))
             }
         }, requestTimeout * 20L)
     }

--- a/src/main/kotlin/event/player/PlayerItemConsume.kt
+++ b/src/main/kotlin/event/player/PlayerItemConsume.kt
@@ -1,5 +1,6 @@
 package event.player
 
+import chat.Formatting.allTags
 import item.booster.BoosterType
 import item.booster.Cards
 import item.crate.CrateType
@@ -26,7 +27,7 @@ class PlayerItemConsume : Listener {
 
             val result = Cards.openBooster(event.player, type)
             if (result == null) {
-                event.player.sendMessage("This booster has no eligible cards configured.")
+                event.player.sendMessage(allTags.deserialize("This booster has no eligible cards configured."))
             }
             return
         }

--- a/src/main/kotlin/util/ui/BinderWindow.kt
+++ b/src/main/kotlin/util/ui/BinderWindow.kt
@@ -5,6 +5,7 @@ import com.noxcrew.interfaces.InterfacesConstants
 import com.noxcrew.interfaces.drawable.Drawable
 import com.noxcrew.interfaces.element.StaticElement
 import com.noxcrew.interfaces.interfaces.buildChestInterface
+import com.noxcrew.interfaces.interfaces.PlayerInventoryType
 import com.noxcrew.interfaces.properties.DelegateTrigger
 import item.binder.BinderItem
 import kotlinx.coroutines.launch
@@ -79,9 +80,9 @@ object BinderWindow {
 
         val iface = buildChestInterface {
             rows = ROWS
-            // Let the player click / pick up items in their own inventory while the binder
-            // is open so they can place cards onto the cursor and insert them.
-            allowClickingOwnInventoryIfClickingEmptySlotsIsPrevented = true
+            // 2.1+ replacement behavior for the removed own-inventory click flag.
+            // DEFAULT keeps player inventory outside the interface mapping, so those clicks are allowed.
+            playerInventoryType = PlayerInventoryType.DEFAULT
             titleSupplier = { _ ->
                 allTags.deserialize("<gradient:#5b9df5:#a78bfa><bold>Card Binder</bold></gradient>")
             }


### PR DESCRIPTION
This pull request introduces several improvements and modernizations to the codebase, focusing on message formatting consistency, API usage updates, and dependency upgrades. The most significant changes are grouped below:

**Message Formatting Consistency:**

* Updated various player-facing messages to use `allTags.deserialize` for consistent formatting across commands and events, including in `Live.kt`, `PlayerItemConsume.kt`, and `Tpa.kt`. [[1]](diffhunk://#diff-b7a3a04dfbbb8ec4df2f4fd39533644d8e6541d8c7fb1d22c9b4f1a0365f8042R4) [[2]](diffhunk://#diff-b7a3a04dfbbb8ec4df2f4fd39533644d8e6541d8c7fb1d22c9b4f1a0365f8042L26-R30) [[3]](diffhunk://#diff-b7a3a04dfbbb8ec4df2f4fd39533644d8e6541d8c7fb1d22c9b4f1a0365f8042L48-R49) [[4]](diffhunk://#diff-b7a3a04dfbbb8ec4df2f4fd39533644d8e6541d8c7fb1d22c9b4f1a0365f8042L57-R58) [[5]](diffhunk://#diff-b7a3a04dfbbb8ec4df2f4fd39533644d8e6541d8c7fb1d22c9b4f1a0365f8042L82-R83) [[6]](diffhunk://#diff-87062003c80c087e8f898e55052c48c3a4b0716bc935123704f3fcf1ca61240fR3) [[7]](diffhunk://#diff-87062003c80c087e8f898e55052c48c3a4b0716bc935123704f3fcf1ca61240fL29-R30) [[8]](diffhunk://#diff-e2d574e166f4cc8de431520be79f540333a5b7d2753b2fd70bf382ed652bce46L201-R202)

**API and Code Modernization:**

* Replaced deprecated or less-preferred Bukkit API usages, such as switching from directly setting `player.inventory.helmet` to `player.inventory.setHelmet()` in `Hat.kt`.
* Updated inventory interface logic in `BinderWindow.kt` to use `PlayerInventoryType.DEFAULT` instead of the removed `allowClickingOwnInventoryIfClickingEmptySlotsIsPrevented` flag, aligning with newer API versions. [[1]](diffhunk://#diff-a1dcdc74ead65d1c2235349a73d45f85f1ad7479bf4e47165b6761fed4601a4dR8) [[2]](diffhunk://#diff-a1dcdc74ead65d1c2235349a73d45f85f1ad7479bf4e47165b6761fed4601a4dL82-R85)

**Dependency Upgrades:**

* Upgraded the `foojay-resolver-convention` Gradle plugin from version `0.9.0` to `1.0.0` in `settings.gradle.kts`.

**Minor Cleanups:**

* Removed an unnecessary line in the self-message branch of the `Message` command.